### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "js-cookie": "^2.2.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
-    "npm": "^6.8.0",
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.8",
     "vue-chartjs": "^3.4.0",


### PR DESCRIPTION

Hello mukesh78!

It seems like you have npm as one of your (dev-) dependency in MarketBridal.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
